### PR TITLE
Fallback pedometer android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,6 +36,7 @@
         </config-file>
 
         <source-file src="src/android/PedoListener.java" target-dir="src/org/apache/cordova/pedometer" />
+        <source-file src="src/android/AccelerometerPedometer.java" target-dir="src/org/apache/cordova/pedometer" />
 
     </platform>
 </plugin>

--- a/src/android/AccelerometerPedometer.java
+++ b/src/android/AccelerometerPedometer.java
@@ -1,0 +1,44 @@
+package org.apache.cordova.pedometer;
+
+import android.hardware.SensorManager;
+
+/**
+ * A simple step counter based on threshold detection.
+ * Created by Dario Salvi.
+ */
+public class AccelerometerPedometer {
+
+    private static final float ALPHA = (float) 0.7;
+    private static final float THRESHOLD = (SensorManager.STANDARD_GRAVITY * 1.15F);
+
+    float lastModule = 0;
+    private long lastStepCountTime = 0;
+
+    private int counter = 0;
+
+    public int getSteps(long timestamp, float accx, float accy, float accz) {
+        long currTime = System.currentTimeMillis();
+
+        float module = (float)(Math.sqrt(Math.pow(accx, 2) + Math.pow(accy, 2) + Math.pow(accz, 2)));
+
+        // Low-pass filter to remove noise
+        module = (1-ALPHA) * lastModule + ALPHA * module;
+
+        // Peak is substantial enough to be correlated to a step
+        // && The condition must not be sustained (an inversion in trend)
+        // && There needs to be at least 300ms between two peaks, otherwise it isn't a step.
+        if((module > THRESHOLD) && (lastModule < THRESHOLD) && (currTime - lastStepCountTime > 300)){
+            counter++;
+            lastStepCountTime = currTime;
+        }
+        lastModule = module;
+
+        return counter;
+    }
+
+    public void reset() {
+        lastModule = 0;
+        lastStepCountTime = 0;
+        counter = 0;
+    }
+}

--- a/src/android/PedoListener.java
+++ b/src/android/PedoListener.java
@@ -150,7 +150,7 @@ public class PedoListener extends CordovaPlugin implements SensorEventListener {
 
         // If found, then register as listener
         if ((list != null) && (list.size() > 0)) {
-            mSensor = list.get(0);
+            mSensor = list.get(0);//get the first one
             if (sensorManager.registerListener(this, mSensor, SensorManager.SENSOR_DELAY_NORMAL)) {
                 running = true;
             } else {
@@ -162,6 +162,7 @@ public class PedoListener extends CordovaPlugin implements SensorEventListener {
             list = sensorManager.getSensorList(Sensor.TYPE_ACCELEROMETER);
 
             if ((list != null) && (list.size() > 0)) {
+                mSensor = list.get(0);//get the first one
                 if (sensorManager.registerListener(this, mSensor, SensorManager.SENSOR_DELAY_NORMAL)) {
                     running = true;
                 } else {
@@ -205,10 +206,10 @@ public class PedoListener extends CordovaPlugin implements SensorEventListener {
         if (event.sensor.getType() == Sensor.TYPE_STEP_COUNTER) {
             float steps = event.values[0];
 
-            if(this.startsteps == 0)
-                this.startsteps = steps;
+            if(startsteps == 0)
+                startsteps = steps;
 
-            steps = steps - this.startsteps;
+            steps = steps - startsteps;
 
             PluginResult result;
             result = new PluginResult(PluginResult.Status.OK, getStepsJSON(steps));
@@ -218,10 +219,13 @@ public class PedoListener extends CordovaPlugin implements SensorEventListener {
             //fallback scenario
             int steps = fallback.getSteps(event.timestamp, event.values[0], event.values[1], event.values[2]);
 
-            PluginResult result;
-            result = new PluginResult(PluginResult.Status.OK, getStepsJSON(steps));
-            result.setKeepCallback(true);
-            callbackContext.sendPluginResult(result);
+            if(startsteps != steps){
+                PluginResult result;
+                result = new PluginResult(PluginResult.Status.OK, getStepsJSON(steps));
+                result.setKeepCallback(true);
+                callbackContext.sendPluginResult(result);
+                startsteps = steps;
+            }
         } else {
             //ignore it
         }
@@ -261,7 +265,7 @@ public class PedoListener extends CordovaPlugin implements SensorEventListener {
         // pedometerData.floorsAscended;
         // pedometerData.floorsDescended;
         try {
-            r.put("startDate", this.starttimestamp);
+            r.put("startDate", starttimestamp);
             r.put("endDate", System.currentTimeMillis());
             r.put("numberOfSteps", steps);
         } catch (JSONException e) {


### PR DESCRIPTION
Hi,

I have added a simple step counter that uses the accelerometer as a fallback scenario when the HW step counter is not available.
It would be good if you could merge this one into yours, as you're the "official" cordova-plugin-pedometer.

One other thing: please update the README, as it says that the plugin is for iOS only and it's not only based on Core Motion (that's an iPhone thing...).

Thanks.
